### PR TITLE
Fix GDT issues; fix assembly code issues; Other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BINARY=os.bin
 CODEDIRS=. lib
 INCDIRS=. ./include/ # can be list
+ASDIRS=.
 
 CCPATH=~/opt/cross/bin
 CC=i686-elf-gcc
@@ -14,22 +15,26 @@ CFLAGS=-std=gnu99 -ffreestanding -Wall -Wextra -g $(foreach D,$(INCDIRS),-I$(D))
 
 # for-style iteration (foreach) and regular expression completions (wildcard)
 CFILES=$(foreach D,$(CODEDIRS),$(wildcard $(D)/*.c))
-ASFILES=$(foreach A,$(ASDIRS),$(wildcard $(D)/*.asm))
+ASFILES=$(foreach D,$(ASDIRS),$(wildcard $(D)/*.s))
 # regular expression replacement
 OBJECTS=$(patsubst %.c,%.o,$(CFILES))
-ASMBS=$(patsubst %.asm,%.o,$(ASFILES))
+ASMBS=$(patsubst %.s,%.o,$(ASFILES))
 DEPFILES=$(patsubst %.c,%.d,$(CFILES))
 
 all: $(BINARY)
 
 $(BINARY): $(OBJECTS) $(ASMBS)
 	@echo "Linking ... "
-	$(CCPATH)/$(CC) -T linker.ld -o $@ -ffreestanding -nostdlib -lgcc boot.o gdts.o paging.o $^
+	$(CCPATH)/$(CC) -T linker.ld -o $@ -ffreestanding -nostdlib -lgcc $^
 	@echo "Done":
 
 # only want the .c file dependency here, thus $< instead of $^.
 #
 %.o:%.c
+	@echo $@ $^
+	$(CCPATH)/$(CC) $(CFLAGS) -c -o $@ $<
+
+%.o:%.s
 	@echo $@ $^
 	$(CCPATH)/$(CC) $(CFLAGS) -c -o $@ $<
 

--- a/boot.s
+++ b/boot.s
@@ -22,13 +22,15 @@ stack_top:
 .global _start
 .type _start, @function
 _start:
- 
-	mov $stack_top, %esp
+	/* Subtract 8 so that with to 4 byte parameters the stack is
+	 * aligned to 16 bytes when kernel_main is called */
+	mov $stack_top-8, %esp
 	/* push the pointer to the Multiboot infromation structure*/
 	push %ebx
 	/* push magic value */
 	push %eax
 
+	cld /* rquired for the System V 32-bit ABI */
 	call kernel_main
 	cli
 1:	hlt

--- a/boot.s
+++ b/boot.s
@@ -22,8 +22,9 @@ stack_top:
 .global _start
 .type _start, @function
 _start:
-	/* Subtract 8 so that with to 4 byte parameters the stack is
-	 * aligned to 16 bytes when kernel_main is called */
+	/* Subtract 8 so that after the 2 32-bit parameters are pushed
+         * on the stack, the stack will still be 16-byte aligned when
+	 * kernel_main is called */
 	mov $stack_top-8, %esp
 	/* push the pointer to the Multiboot infromation structure*/
 	push %ebx

--- a/gdt_asm.s
+++ b/gdt_asm.s
@@ -1,3 +1,5 @@
+.intel_syntax noprefix
+
 .section .text
 .global gdt_flush
 .extern gdt_ptr
@@ -10,7 +12,7 @@ gdt_flush:
     mov %fs, %ax
     mov %gs, %ax
     mov %ss, %ax
-    jmp flush2          # Jump to flush2 with the code segment selector
+    jmp 0x08:flush2          # Jump to flush2 with the code segment selector
 
 flush2:
     ret                       # Return from the function

--- a/include/gdt.h
+++ b/include/gdt.h
@@ -5,9 +5,9 @@ struct gdt_segment {
 	uint16_t limit_low;
 	uint16_t base_low;
 	uint8_t base_middle;
-	uint8_t base_high;
 	uint8_t access;
 	uint8_t granularity;
+	uint8_t base_high;
 } __attribute__((packed));
 
 struct gdt_ptr_struct {

--- a/lib/gdt.c
+++ b/lib/gdt.c
@@ -10,7 +10,6 @@ void initSegment(int num, uint32_t limit, uint32_t base, uint8_t access, uint8_t
 	gdt_entries[num].base_high = (base >> 24) & 0xFF;
 	gdt_entries[num].access = access;
 	gdt_entries[num].granularity = (limit >> 16) & 0x0F;
-//	gdt_entries[num].granularity |= gdt_entries[num].granularity;
 	gdt_entries[num].granularity |= (gran & 0xF0);
 }
 

--- a/lib/gdt.c
+++ b/lib/gdt.c
@@ -10,7 +10,8 @@ void initSegment(int num, uint32_t limit, uint32_t base, uint8_t access, uint8_t
 	gdt_entries[num].base_high = (base >> 24) & 0xFF;
 	gdt_entries[num].access = access;
 	gdt_entries[num].granularity = (limit >> 16) & 0x0F;
-	gdt_entries[num].granularity |= gdt_entries[num].granularity;
+//	gdt_entries[num].granularity |= gdt_entries[num].granularity;
+	gdt_entries[num].granularity |= (gran & 0xF0);
 }
 
 void initGdt() {
@@ -18,8 +19,8 @@ void initGdt() {
 	gdt_ptr.base = (unsigned int)gdt_entries;
 
 	initSegment(0, 0, 0, 0, 0);
-	initSegment(1, 0xFFFFFFFF, 0, 0x92, 0xCF); //kernel code segment
-	initSegment(2, 0, 0xFFFFFFFF, 0x92, 0xCF); //kernel data segment
+	initSegment(1, 0xFFFFFFFF, 0, 0x9A, 0xCF); //kernel code segment
+	initSegment(2, 0xFFFFFFFF, 0, 0x92, 0xCF); //kernel data segment
 	//initSegment(3, 0xFFFFFFFF, 0, 0xFA, 0xCF); //user code
 	//initSegment(4, 0xFFFFFFFF, 0, 0xF2, 0xCF); //user code
 	

--- a/lib/kernel.c
+++ b/lib/kernel.c
@@ -116,7 +116,7 @@ void terminal_writestring(const char* data)
 
 //for now
 void print_hex(uint32_t value) {
-	char hex[8];
+	char hex[9];
 	int i = 8;
 	for (; i >= 0; i--) {
 		int digit = (value >> (i * 4)) & 0xf;

--- a/lib/pmm.c
+++ b/lib/pmm.c
@@ -26,7 +26,7 @@ void set_page_free(uint32_t bit, uint8_t* map) {
 
 void initPMM(struct multiboot_info* mbt) {
 	tws("\nInitializing Physical Memory Manager\n");
-	for (int i = 0; i < mbt->mmap_length; i += sizeof(struct multiboot_mmap_entry)) {
+	for (unsigned int i = 0; i < mbt->mmap_length; i += sizeof(struct multiboot_mmap_entry)) {
 		struct multiboot_mmap_entry *mmt  = (struct multiboot_mmap_entry*)(mbt->mmap_addr+i);
 		if (mmt->type == MULTIBOOT_MEMORY_AVAILABLE) {
             uint32_t start_page = mmt->addr_low / PAGE_SIZE ;

--- a/lib/virtual_memory_map.c
+++ b/lib/virtual_memory_map.c
@@ -9,6 +9,9 @@ void init_paging() {
 	}
 
 	//we will fill all 1024 entries in the table, mapping 4 megabytes
+	//except for the first 4KiB to capture any possible NULL pointer
+	//dereferencing or other bugs. use `i=0` to map the first 4KiB if
+	//you wish.
 	for(unsigned int i = 1; i < 1024; i++)
 	{
 		// As the address is page aligned, it will always leave 12 bits zeroed.

--- a/lib/virtual_memory_map.c
+++ b/lib/virtual_memory_map.c
@@ -9,7 +9,7 @@ void init_paging() {
 	}
 
 	//we will fill all 1024 entries in the table, mapping 4 megabytes
-	for(unsigned int i = 0; i < 1024; i++)
+	for(unsigned int i = 1; i < 1024; i++)
 	{
 		// As the address is page aligned, it will always leave 12 bits zeroed.
 		// Those bits are used by the attributes ;)

--- a/linker.ld
+++ b/linker.ld
@@ -3,19 +3,17 @@ ENTRY(_start)
 SECTIONS {
 	. = 2M;
 	.text BLOCK(4K) : ALIGN(4K) {
-		*(.text)
-		*(.text.*)
+		*(.multiboot)
+		*(.text*)
 	}
 	.rodata BLOCK(4K) : ALIGN(4K) {
-		*(.rodata)
-		*(.rodata.)
+		*(.rodata*)
 	}
 	.data  BLOCK(4K) : ALIGN(4K) {
 		*(.data)
-		*(.data.)
 	}
 	.bss BLOCK(4K) : ALIGN(4K) {
 		*(.bss)
-		*(.bss.)
+		*(COMMON)
 	}
 }

--- a/paging.s
+++ b/paging.s
@@ -20,3 +20,4 @@ enablePaging:
     mov %ebp, %esp
     pop %ebp
     ret
+


### PR DESCRIPTION
- Fix GDT issues
- Fix assembly file issues
- Modify `init_paging` to not map the first 4KiB to catch possible bugs including NULL pointer references. See the code comments to remove this behaviour.
- Rename GNU assembler files from `.asm` to `.s` extension
- Fix `Makefile` to assemble `.s` files
- Cleanup `linker.ld` 
- Other bug fixes